### PR TITLE
Migrate : set variable values via command arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ The tool supported the following options:
 - `--password=<password>`: Specify the database password. Tool will ask if not specified.
 - `--[no-]ssl`: Specify whether or not this connection should connect securely. Tool will ask if not specified.
 - `--[no-]unix-socket`: Specify Whether or not the connection is made via unix socket. Tool will ask if not specified.
+- `--defaults`: Specify Whether to use default values except for the values provided via arguments or environment variables.
 - `--dry-run`: Logs any changes to the schema without writing to the database, and exists
   with code 1 if there are any.
 - `--apply-changes`: Apply any changes without asking for confirmation.

--- a/README.md
+++ b/README.md
@@ -428,6 +428,12 @@ The tool supported the following options:
 
 - `-h`: Shows the available options.
 - `--db=<db_name>`: Specify the database name. Tool will ask if not specified.
+- `--host=<host_address>`: Specify the database host address. Tool will ask if not specified.
+- `--port=<port>`: Specify the database port. Tool will ask if not specified.
+- `--username=<username>`: Specify the database username. Tool will ask if not specified.
+- `--password=<password>`: Specify the database password. Tool will ask if not specified.
+- `--ssl=<ssl>`: Specify if the connection use SSL or not. Tool will ask if not specified.
+- `--socket=<socket>`: Specify if the connection use unix socket or not. Tool will ask if not specified.
 - `--dry-run`: Logs any changes to the schema without writing to the database, and exists
   with code 1 if there are any.
 - `--apply-changes`: Apply any changes without asking for confirmation.

--- a/README.md
+++ b/README.md
@@ -432,8 +432,8 @@ The tool supported the following options:
 - `--port=<port>`: Specify the database port. Tool will ask if not specified.
 - `--username=<username>`: Specify the database username. Tool will ask if not specified.
 - `--password=<password>`: Specify the database password. Tool will ask if not specified.
-- `--ssl=<ssl>`: Specify if the connection use SSL or not. Tool will ask if not specified.
-- `--socket=<socket>`: Specify if the connection use unix socket or not. Tool will ask if not specified.
+- `--[no-]ssl`: Specify whether or not this connection should connect securely. Tool will ask if not specified.
+- `--[no-]unix-socket`: Specify Whether or not the connection is made via unix socket. Tool will ask if not specified.
 - `--dry-run`: Logs any changes to the schema without writing to the database, and exists
   with code 1 if there are any.
 - `--apply-changes`: Apply any changes without asking for confirmation.

--- a/lib/src/cli/runner.dart
+++ b/lib/src/cli/runner.dart
@@ -24,8 +24,20 @@ class MigrateCommand extends Command<void> {
     argParser.addOption('port', help: 'Set the database port.');
     argParser.addOption('username', help: 'Set the database username.');
     argParser.addOption('password', help: 'Set the database password.');
-    argParser.addOption('ssl', help: 'Whether or not this connection should connect securely.');
-    argParser.addOption('socket', help: 'If true, connection is made via unix socket.');
+
+    argParser.addFlag(
+      'ssl',
+      negatable: true,
+      defaultsTo: null,
+      help: 'Whether or not this connection should connect securely.',
+    );
+
+    argParser.addFlag(
+      'unix-socket',
+      negatable: true,
+      defaultsTo: null,
+      help: 'Whether or not the connection is made via unix socket.',
+    );
 
     argParser.addOption(
       'output',
@@ -57,8 +69,8 @@ class MigrateCommand extends Command<void> {
     String? dbName = argResults!['db'] as String?;
     String? dbUsername = argResults!['username'] as String?;
     String? dbPassword = argResults!['password'] as String?;
-    String? dbSSL = argResults!['ssl'] as String?;
-    String? dbSocket = argResults!['socket'] as String?;
+    bool? dbSSL = argResults!['ssl'] as bool?;
+    bool? dbSocket = argResults!['unix-socket'] as bool?;
 
     var pubspecYaml = File('pubspec.yaml');
 
@@ -118,7 +130,7 @@ class MigrateCommand extends Command<void> {
     }
 
     if (dbName == null && Platform.environment['DB_NAME'] == null) {
-      stdout.write('Select a database to update: ');
+      stdout.write('Select a database to update : ');
       dbName = stdin.readLineSync(encoding: Encoding.getByName('utf-8')!);
     }
 
@@ -151,7 +163,12 @@ class MigrateCommand extends Command<void> {
 
     if (dbPassword == null && Platform.environment['DB_PASSWORD'] == null) {
       stdout.write('Enter the DB password : ');
+      stdin.echoMode = false;
+
       dbPassword = stdin.readLineSync(encoding: Encoding.getByName('utf-8')!);
+
+      stdin.echoMode = true;
+      stdout.writeln();
 
       if (dbPassword?.isEmpty ?? true) {
         dbPassword = null;

--- a/lib/src/cli/runner.dart
+++ b/lib/src/cli/runner.dart
@@ -178,14 +178,14 @@ class MigrateCommand extends Command<void> {
     bool? useSSL = dbSSL;
     bool? isUnixSocket = dbSocket;
 
-    if (dbSSL == null && Platform.environment['DB_SSL'] == null) {
+    if (useSSL == null && Platform.environment['DB_SSL'] == null) {
       stdout.write('Use SSL ? (yes/no): ');
       final input = stdin.readLineSync(encoding: Encoding.getByName('utf-8')!);
 
       useSSL = input == null ? null : input == 'yes';
     }
 
-    if (dbSocket == null && Platform.environment['DB_SOCKET'] == null) {
+    if (isUnixSocket == null && Platform.environment['DB_SOCKET'] == null) {
       stdout.write('Use unix socket ? (yes/no): ');
       final input = stdin.readLineSync(encoding: Encoding.getByName('utf-8')!);
 

--- a/lib/src/cli/runner.dart
+++ b/lib/src/cli/runner.dart
@@ -175,8 +175,8 @@ class MigrateCommand extends Command<void> {
       }
     }
 
-    bool? useSSL;
-    bool? isUnixSocket;
+    bool? useSSL = dbSSL;
+    bool? isUnixSocket = dbSocket;
 
     if (dbSSL == null && Platform.environment['DB_SSL'] == null) {
       stdout.write('Use SSL ? (yes/no): ');

--- a/lib/src/cli/runner.dart
+++ b/lib/src/cli/runner.dart
@@ -39,6 +39,13 @@ class MigrateCommand extends Command<void> {
       help: 'Whether or not the connection is made via unix socket.',
     );
 
+    argParser.addFlag(
+      'defaults',
+      negatable: false,
+      help:
+          'Use default values except for the values provided via arguments or environment variables',
+    );
+
     argParser.addOption(
       'output',
       abbr: 'o',
@@ -64,6 +71,7 @@ class MigrateCommand extends Command<void> {
     bool dryRun = argResults!['dry-run'] as bool;
     String? output = argResults!['output'] as String?;
     bool applyChanges = argResults!['apply-changes'] as bool;
+    bool useDefaults = argResults!['defaults'] as bool;
     String? dbHostAddress = argResults!['host'] as String?;
     int? dbPort = argResults!['port'] as int?;
     String? dbName = argResults!['db'] as String?;
@@ -129,12 +137,13 @@ class MigrateCommand extends Command<void> {
       schema = schema.mergeWith(targetSchema);
     }
 
-    if (dbName == null && Platform.environment['DB_NAME'] == null) {
+    if (!useDefaults &&
+        dbName == null && Platform.environment['DB_NAME'] == null) {
       stdout.write('Select a database to update : ');
       dbName = stdin.readLineSync(encoding: Encoding.getByName('utf-8')!);
     }
 
-    if (dbHostAddress == null &&
+    if (!useDefaults && dbHostAddress == null &&
         Platform.environment['DB_HOST_ADDRESS'] == null) {
       stdout.write('Enter the DB host address : ');
       dbHostAddress =
@@ -145,14 +154,16 @@ class MigrateCommand extends Command<void> {
       }
     }
 
-    if (dbPort == null && Platform.environment['DB_PORT'] == null) {
+    if (!useDefaults &&
+        dbPort == null && Platform.environment['DB_PORT'] == null) {
       stdout.write('Enter the DB port : ');
       final input = stdin.readLineSync();
 
       dbPort = int.tryParse(input ?? '');
     }
 
-    if (dbUsername == null && Platform.environment['DB_USERNAME'] == null) {
+    if (!useDefaults &&
+        dbUsername == null && Platform.environment['DB_USERNAME'] == null) {
       stdout.write('Enter the DB username : ');
       dbUsername = stdin.readLineSync(encoding: Encoding.getByName('utf-8')!);
 
@@ -161,7 +172,8 @@ class MigrateCommand extends Command<void> {
       }
     }
 
-    if (dbPassword == null && Platform.environment['DB_PASSWORD'] == null) {
+    if (!useDefaults &&
+        dbPassword == null && Platform.environment['DB_PASSWORD'] == null) {
       stdout.write('Enter the DB password : ');
       stdin.echoMode = false;
 
@@ -178,14 +190,16 @@ class MigrateCommand extends Command<void> {
     bool? useSSL = dbSSL;
     bool? isUnixSocket = dbSocket;
 
-    if (useSSL == null && Platform.environment['DB_SSL'] == null) {
+    if (!useDefaults &&
+        useSSL == null && Platform.environment['DB_SSL'] == null) {
       stdout.write('Use SSL ? (yes/no): ');
       final input = stdin.readLineSync(encoding: Encoding.getByName('utf-8')!);
 
       useSSL = input == null ? null : input == 'yes';
     }
 
-    if (isUnixSocket == null && Platform.environment['DB_SOCKET'] == null) {
+    if (!useDefaults &&
+        isUnixSocket == null && Platform.environment['DB_SOCKET'] == null) {
       stdout.write('Use unix socket ? (yes/no): ');
       final input = stdin.readLineSync(encoding: Encoding.getByName('utf-8')!);
 

--- a/lib/src/core/database.dart
+++ b/lib/src/core/database.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 import 'package:postgres/postgres.dart';
 
+import 'default_values.dart';
+
 class Database {
   bool debugPrint;
 
@@ -35,13 +37,13 @@ class Database {
     bool? isUnixSocket,
     this.allowClearTextPassword = false,
     this.replicationMode = ReplicationMode.none,
-  })  : host = host ?? Platform.environment['DB_HOST_ADDRESS'] ?? '127.0.0.1',
-        port = port ?? int.tryParse(Platform.environment['DB_PORT'] ?? '') ?? 5432,
-        database = database ?? Platform.environment['DB_NAME'] ?? 'postgres',
-        user = user ?? Platform.environment['DB_USERNAME'] ?? 'postgres',
-        password = password ?? Platform.environment['DB_PASSWORD'] ?? 'root',
-        useSSL = useSSL ?? (Platform.environment['DB_SSL'] != 'false'),
-        isUnixSocket = isUnixSocket ?? (Platform.environment['DB_SOCKET'] == 'true')
+  })  : host = host ?? Platform.environment['DB_HOST_ADDRESS'] ?? DB_HOST_ADDRESS,
+        port = port ?? int.tryParse(Platform.environment['DB_PORT'] ?? '') ?? DB_PORT,
+        database = database ?? Platform.environment['DB_NAME'] ?? DB_NAME,
+        user = user ?? Platform.environment['DB_USERNAME'] ?? DB_USERNAME,
+        password = password ?? Platform.environment['DB_PASSWORD'] ?? DB_PASSWORD,
+        useSSL = useSSL ?? (Platform.environment['DB_SSL'] != DB_SSL),
+        isUnixSocket = isUnixSocket ?? (Platform.environment['DB_SOCKET'] == DB_SOCKET)
   {
     _cachedConnection ??= connection();
   }

--- a/lib/src/core/default_values.dart
+++ b/lib/src/core/default_values.dart
@@ -1,0 +1,9 @@
+// ignore_for_file: constant_identifier_names
+
+const String DB_HOST_ADDRESS = '127.0.0.1';
+const int DB_PORT = 5432;
+const String DB_NAME = 'postgres';
+const String DB_USERNAME = 'postgres';
+const String DB_PASSWORD = 'root';
+const String DB_SSL = 'false';
+const String DB_SOCKET = 'true';


### PR DESCRIPTION
## Migrate 

Provide 2 ways to change values for variables if environment variables are not specified. 

1. Provide via command line arguments
2. Provide when asked if not provided via command line arguments or not specified in environment variables

This is a fix for the issue I found when assigning variable values in windows PowerShell using Set-Variable.

