### PR TITLE
Make Repositories extension unique across generated files

### DIFF
--- a/example/lib/model.schema.dart
+++ b/example/lib/model.schema.dart
@@ -1,6 +1,6 @@
 part of 'model.dart';
 
-extension Repositories on Database {
+extension ModelRepositories on Database {
   ARepository get as => ARepository._(this);
   BRepository get bs => BRepository._(this);
 }

--- a/example/lib/models/address.schema.dart
+++ b/example/lib/models/address.schema.dart
@@ -1,6 +1,6 @@
 part of 'address.dart';
 
-extension Repositories on Database {
+extension AddressRepositories on Database {
   BillingAddressRepository get billingAddresses => BillingAddressRepository._(this);
 }
 
@@ -30,8 +30,8 @@ class _BillingAddressRepository extends BaseRepository
 
     var values = QueryValues();
     await db.query(
-      'INSERT INTO "billing_addresses" ( "account_id", "company_id", "city", "postcode", "name", "street" )\n'
-      'VALUES ${requests.map((r) => '( ${values.add(r.accountId)}, ${values.add(r.companyId)}, ${values.add(r.city)}, ${values.add(r.postcode)}, ${values.add(r.name)}, ${values.add(r.street)} )').join(', ')}\n',
+      'INSERT INTO "billing_addresses" ( "company_id", "account_id", "city", "postcode", "name", "street" )\n'
+      'VALUES ${requests.map((r) => '( ${values.add(r.companyId)}, ${values.add(r.accountId)}, ${values.add(r.city)}, ${values.add(r.postcode)}, ${values.add(r.name)}, ${values.add(r.street)} )').join(', ')}\n',
       values.values,
     );
   }
@@ -43,9 +43,9 @@ class _BillingAddressRepository extends BaseRepository
     await db.query(
       'UPDATE "billing_addresses"\n'
       'SET "city" = COALESCE(UPDATED."city"::text, "billing_addresses"."city"), "postcode" = COALESCE(UPDATED."postcode"::text, "billing_addresses"."postcode"), "name" = COALESCE(UPDATED."name"::text, "billing_addresses"."name"), "street" = COALESCE(UPDATED."street"::text, "billing_addresses"."street")\n'
-      'FROM ( VALUES ${requests.map((r) => '( ${values.add(r.accountId)}, ${values.add(r.companyId)}, ${values.add(r.city)}, ${values.add(r.postcode)}, ${values.add(r.name)}, ${values.add(r.street)} )').join(', ')} )\n'
-      'AS UPDATED("account_id", "company_id", "city", "postcode", "name", "street")\n'
-      'WHERE "billing_addresses"."account_id" = UPDATED."account_id" AND "billing_addresses"."company_id" = UPDATED."company_id"',
+      'FROM ( VALUES ${requests.map((r) => '( ${values.add(r.companyId)}, ${values.add(r.accountId)}, ${values.add(r.city)}, ${values.add(r.postcode)}, ${values.add(r.name)}, ${values.add(r.street)} )').join(', ')} )\n'
+      'AS UPDATED("company_id", "account_id", "city", "postcode", "name", "street")\n'
+      'WHERE "billing_addresses"."company_id" = UPDATED."company_id" AND "billing_addresses"."account_id" = UPDATED."account_id"',
       values.values,
     );
   }
@@ -53,16 +53,16 @@ class _BillingAddressRepository extends BaseRepository
 
 class BillingAddressInsertRequest {
   BillingAddressInsertRequest({
-    this.accountId,
     this.companyId,
+    this.accountId,
     required this.city,
     required this.postcode,
     required this.name,
     required this.street,
   });
 
-  int? accountId;
   String? companyId;
+  int? accountId;
   String city;
   String postcode;
   String name;
@@ -71,16 +71,16 @@ class BillingAddressInsertRequest {
 
 class BillingAddressUpdateRequest {
   BillingAddressUpdateRequest({
-    this.accountId,
     this.companyId,
+    this.accountId,
     this.city,
     this.postcode,
     this.name,
     this.street,
   });
 
-  int? accountId;
   String? companyId;
+  int? accountId;
   String? city;
   String? postcode;
   String? name;

--- a/example/lib/models/company.schema.dart
+++ b/example/lib/models/company.schema.dart
@@ -1,6 +1,6 @@
 part of 'company.dart';
 
-extension Repositories on Database {
+extension CompanyRepositories on Database {
   CompanyRepository get companies => CompanyRepository._(this);
 }
 
@@ -58,7 +58,7 @@ class _CompanyRepository extends BaseRepository
     );
     await db.billingAddresses.insertMany(requests.expand((r) {
       return r.addresses.map((rr) => BillingAddressInsertRequest(
-          accountId: null, companyId: r.id, city: rr.city, postcode: rr.postcode, name: rr.name, street: rr.street));
+          companyId: r.id, accountId: null, city: rr.city, postcode: rr.postcode, name: rr.name, street: rr.street));
     }).toList());
   }
 
@@ -114,8 +114,22 @@ class FullCompanyViewQueryable extends KeyedViewQueryable<FullCompanyView, Strin
 
   @override
   String get query =>
-      'SELECT "companies".*, "invoices"."data" as "invoices", "parties"."data" as "parties", "members"."data" as "members", "addresses"."data" as "addresses"'
+      'SELECT "companies".*, "addresses"."data" as "addresses", "members"."data" as "members", "invoices"."data" as "invoices", "parties"."data" as "parties"'
       'FROM "companies"'
+      'LEFT JOIN ('
+      '  SELECT "billing_addresses"."company_id",'
+      '    to_jsonb(array_agg("billing_addresses".*)) as data'
+      '  FROM (${BillingAddressQueryable().query}) "billing_addresses"'
+      '  GROUP BY "billing_addresses"."company_id"'
+      ') "addresses"'
+      'ON "companies"."id" = "addresses"."company_id"'
+      'LEFT JOIN ('
+      '  SELECT "accounts"."company_id",'
+      '    to_jsonb(array_agg("accounts".*)) as data'
+      '  FROM (${CompanyAccountViewQueryable().query}) "accounts"'
+      '  GROUP BY "accounts"."company_id"'
+      ') "members"'
+      'ON "companies"."id" = "members"."company_id"'
       'LEFT JOIN ('
       '  SELECT "invoices"."company_id",'
       '    to_jsonb(array_agg("invoices".*)) as data'
@@ -129,51 +143,37 @@ class FullCompanyViewQueryable extends KeyedViewQueryable<FullCompanyView, Strin
       '  FROM (${CompanyPartyViewQueryable().query}) "parties"'
       '  GROUP BY "parties"."sponsor_id"'
       ') "parties"'
-      'ON "companies"."id" = "parties"."sponsor_id"'
-      'LEFT JOIN ('
-      '  SELECT "accounts"."company_id",'
-      '    to_jsonb(array_agg("accounts".*)) as data'
-      '  FROM (${CompanyAccountViewQueryable().query}) "accounts"'
-      '  GROUP BY "accounts"."company_id"'
-      ') "members"'
-      'ON "companies"."id" = "members"."company_id"'
-      'LEFT JOIN ('
-      '  SELECT "billing_addresses"."company_id",'
-      '    to_jsonb(array_agg("billing_addresses".*)) as data'
-      '  FROM (${BillingAddressQueryable().query}) "billing_addresses"'
-      '  GROUP BY "billing_addresses"."company_id"'
-      ') "addresses"'
-      'ON "companies"."id" = "addresses"."company_id"';
+      'ON "companies"."id" = "parties"."sponsor_id"';
 
   @override
   String get tableAlias => 'companies';
 
   @override
   FullCompanyView decode(TypedMap map) => FullCompanyView(
-      invoices: map.getListOpt('invoices', OwnerInvoiceViewQueryable().decoder) ?? const [],
-      parties: map.getListOpt('parties', CompanyPartyViewQueryable().decoder) ?? const [],
-      members: map.getListOpt('members', CompanyAccountViewQueryable().decoder) ?? const [],
       id: map.get('id', TextEncoder.i.decode),
       name: map.get('name', TextEncoder.i.decode),
-      addresses: map.getListOpt('addresses', BillingAddressQueryable().decoder) ?? const []);
+      addresses: map.getListOpt('addresses', BillingAddressQueryable().decoder) ?? const [],
+      members: map.getListOpt('members', CompanyAccountViewQueryable().decoder) ?? const [],
+      invoices: map.getListOpt('invoices', OwnerInvoiceViewQueryable().decoder) ?? const [],
+      parties: map.getListOpt('parties', CompanyPartyViewQueryable().decoder) ?? const []);
 }
 
 class FullCompanyView {
   FullCompanyView({
-    required this.invoices,
-    required this.parties,
-    required this.members,
     required this.id,
     required this.name,
     required this.addresses,
+    required this.members,
+    required this.invoices,
+    required this.parties,
   });
 
-  final List<OwnerInvoiceView> invoices;
-  final List<CompanyPartyView> parties;
-  final List<CompanyAccountView> members;
   final String id;
   final String name;
   final List<BillingAddress> addresses;
+  final List<CompanyAccountView> members;
+  final List<OwnerInvoiceView> invoices;
+  final List<CompanyPartyView> parties;
 }
 
 class MemberCompanyViewQueryable extends KeyedViewQueryable<MemberCompanyView, String> {

--- a/example/lib/models/invoice.schema.dart
+++ b/example/lib/models/invoice.schema.dart
@@ -1,6 +1,6 @@
 part of 'invoice.dart';
 
-extension Repositories on Database {
+extension InvoiceRepositories on Database {
   InvoiceRepository get invoices => InvoiceRepository._(this);
 }
 
@@ -40,8 +40,8 @@ class _InvoiceRepository extends BaseRepository
 
     var values = QueryValues();
     await db.query(
-      'INSERT INTO "invoices" ( "id", "title", "invoice_id", "account_id", "company_id" )\n'
-      'VALUES ${requests.map((r) => '( ${values.add(r.id)}, ${values.add(r.title)}, ${values.add(r.invoiceId)}, ${values.add(r.accountId)}, ${values.add(r.companyId)} )').join(', ')}\n',
+      'INSERT INTO "invoices" ( "company_id", "id", "title", "invoice_id", "account_id" )\n'
+      'VALUES ${requests.map((r) => '( ${values.add(r.companyId)}, ${values.add(r.id)}, ${values.add(r.title)}, ${values.add(r.invoiceId)}, ${values.add(r.accountId)} )').join(', ')}\n',
       values.values,
     );
   }
@@ -52,9 +52,9 @@ class _InvoiceRepository extends BaseRepository
     var values = QueryValues();
     await db.query(
       'UPDATE "invoices"\n'
-      'SET "title" = COALESCE(UPDATED."title"::text, "invoices"."title"), "invoice_id" = COALESCE(UPDATED."invoice_id"::text, "invoices"."invoice_id"), "account_id" = COALESCE(UPDATED."account_id"::int8, "invoices"."account_id"), "company_id" = COALESCE(UPDATED."company_id"::text, "invoices"."company_id")\n'
-      'FROM ( VALUES ${requests.map((r) => '( ${values.add(r.id)}, ${values.add(r.title)}, ${values.add(r.invoiceId)}, ${values.add(r.accountId)}, ${values.add(r.companyId)} )').join(', ')} )\n'
-      'AS UPDATED("id", "title", "invoice_id", "account_id", "company_id")\n'
+      'SET "company_id" = COALESCE(UPDATED."company_id"::text, "invoices"."company_id"), "title" = COALESCE(UPDATED."title"::text, "invoices"."title"), "invoice_id" = COALESCE(UPDATED."invoice_id"::text, "invoices"."invoice_id"), "account_id" = COALESCE(UPDATED."account_id"::int8, "invoices"."account_id")\n'
+      'FROM ( VALUES ${requests.map((r) => '( ${values.add(r.companyId)}, ${values.add(r.id)}, ${values.add(r.title)}, ${values.add(r.invoiceId)}, ${values.add(r.accountId)} )').join(', ')} )\n'
+      'AS UPDATED("company_id", "id", "title", "invoice_id", "account_id")\n'
       'WHERE "invoices"."id" = UPDATED."id"',
       values.values,
     );
@@ -63,34 +63,34 @@ class _InvoiceRepository extends BaseRepository
 
 class InvoiceInsertRequest {
   InvoiceInsertRequest({
+    this.companyId,
     required this.id,
     required this.title,
     required this.invoiceId,
     this.accountId,
-    this.companyId,
   });
 
+  String? companyId;
   String id;
   String title;
   String invoiceId;
   int? accountId;
-  String? companyId;
 }
 
 class InvoiceUpdateRequest {
   InvoiceUpdateRequest({
+    this.companyId,
     required this.id,
     this.title,
     this.invoiceId,
     this.accountId,
-    this.companyId,
   });
 
+  String? companyId;
   String id;
   String? title;
   String? invoiceId;
   int? accountId;
-  String? companyId;
 }
 
 class OwnerInvoiceViewQueryable extends KeyedViewQueryable<OwnerInvoiceView, String> {

--- a/example/lib/models/party.schema.dart
+++ b/example/lib/models/party.schema.dart
@@ -1,6 +1,6 @@
 part of 'party.dart';
 
-extension Repositories on Database {
+extension PartyRepositories on Database {
   PartyRepository get parties => PartyRepository._(this);
 }
 
@@ -52,8 +52,8 @@ class _PartyRepository extends BaseRepository
 
     var values = QueryValues();
     await db.query(
-      'INSERT INTO "parties" ( "id", "name", "sponsor_id", "date" )\n'
-      'VALUES ${requests.map((r) => '( ${values.add(r.id)}, ${values.add(r.name)}, ${values.add(r.sponsorId)}, ${values.add(r.date)} )').join(', ')}\n',
+      'INSERT INTO "parties" ( "sponsor_id", "id", "name", "date" )\n'
+      'VALUES ${requests.map((r) => '( ${values.add(r.sponsorId)}, ${values.add(r.id)}, ${values.add(r.name)}, ${values.add(r.date)} )').join(', ')}\n',
       values.values,
     );
   }
@@ -64,9 +64,9 @@ class _PartyRepository extends BaseRepository
     var values = QueryValues();
     await db.query(
       'UPDATE "parties"\n'
-      'SET "name" = COALESCE(UPDATED."name"::text, "parties"."name"), "sponsor_id" = COALESCE(UPDATED."sponsor_id"::text, "parties"."sponsor_id"), "date" = COALESCE(UPDATED."date"::int8, "parties"."date")\n'
-      'FROM ( VALUES ${requests.map((r) => '( ${values.add(r.id)}, ${values.add(r.name)}, ${values.add(r.sponsorId)}, ${values.add(r.date)} )').join(', ')} )\n'
-      'AS UPDATED("id", "name", "sponsor_id", "date")\n'
+      'SET "sponsor_id" = COALESCE(UPDATED."sponsor_id"::text, "parties"."sponsor_id"), "name" = COALESCE(UPDATED."name"::text, "parties"."name"), "date" = COALESCE(UPDATED."date"::int8, "parties"."date")\n'
+      'FROM ( VALUES ${requests.map((r) => '( ${values.add(r.sponsorId)}, ${values.add(r.id)}, ${values.add(r.name)}, ${values.add(r.date)} )').join(', ')} )\n'
+      'AS UPDATED("sponsor_id", "id", "name", "date")\n'
       'WHERE "parties"."id" = UPDATED."id"',
       values.values,
     );
@@ -75,29 +75,29 @@ class _PartyRepository extends BaseRepository
 
 class PartyInsertRequest {
   PartyInsertRequest({
+    this.sponsorId,
     required this.id,
     required this.name,
-    this.sponsorId,
     required this.date,
   });
 
+  String? sponsorId;
   String id;
   String name;
-  String? sponsorId;
   int date;
 }
 
 class PartyUpdateRequest {
   PartyUpdateRequest({
+    this.sponsorId,
     required this.id,
     this.name,
-    this.sponsorId,
     this.date,
   });
 
+  String? sponsorId;
   String id;
   String? name;
-  String? sponsorId;
   int? date;
 }
 
@@ -119,23 +119,23 @@ class GuestPartyViewQueryable extends KeyedViewQueryable<GuestPartyView, String>
 
   @override
   GuestPartyView decode(TypedMap map) => GuestPartyView(
+      sponsor: map.getOpt('sponsor', MemberCompanyViewQueryable().decoder),
       id: map.get('id', TextEncoder.i.decode),
       name: map.get('name', TextEncoder.i.decode),
-      sponsor: map.getOpt('sponsor', MemberCompanyViewQueryable().decoder),
       date: map.get('date', TextEncoder.i.decode));
 }
 
 class GuestPartyView {
   GuestPartyView({
+    this.sponsor,
     required this.id,
     required this.name,
-    this.sponsor,
     required this.date,
   });
 
+  final MemberCompanyView? sponsor;
   final String id;
   final String name;
-  final MemberCompanyView? sponsor;
   final int date;
 }
 

--- a/lib/src/builder/elements/table_element.dart
+++ b/lib/src/builder/elements/table_element.dart
@@ -89,8 +89,9 @@ class TableElement {
       : null;
 
   void prepareColumns() {
-    final allFields =
-        element.fields.followedBy(element.allSupertypes.expand((t) => t.isDartCoreObject ? [] : t.element.fields));
+    final allFields = element.fields
+        .cast<FieldElement>()
+        .followedBy(element.allSupertypes.expand((t) => t.isDartCoreObject ? [] : t.element.fields));
 
     for (var param in allFields) {
       if (columns.any((c) => c.parameter == param)) {
@@ -124,7 +125,8 @@ class TableElement {
         }
 
         if (selfHasKey && otherHasKey && !selfIsList && !otherIsList) {
-          var eitherNullable = param.type.nullabilitySuffix != NullabilitySuffix.none || otherParam!.type.nullabilitySuffix != NullabilitySuffix.none;
+          var eitherNullable = param.type.nullabilitySuffix != NullabilitySuffix.none ||
+              otherParam!.type.nullabilitySuffix != NullabilitySuffix.none;
           if (!eitherNullable) {
             throw 'Model ${otherBuilder.element.name} cannot have a one-to-one relation to model ${element.name} with '
                 'both sides being non-nullable. At least one side has to be nullable, to insert one model before the other.\n'

--- a/lib/src/builder/generators/repository_generator.dart
+++ b/lib/src/builder/generators/repository_generator.dart
@@ -1,6 +1,6 @@
-import 'package:recase/recase.dart';
 import 'package:path/path.dart' as p;
 
+import '../../core/case_style.dart';
 import '../schema.dart';
 import '../elements/table_element.dart';
 import 'insert_generator.dart';
@@ -10,7 +10,7 @@ import 'view_generator.dart';
 class RepositoryGenerator {
   String generateRepositories(AssetState state) {
     return '''
-    extension ${p.withoutExtension(state.filename).pascalCase}Repositories on Database {
+    extension ${CaseStyle.pascalCase.transform(p.withoutExtension(state.filename))}Repositories on Database {
       ${state.tables.values.map((b) => '  ${b.element.name}Repository get ${b.repoName} => ${b.element.name}Repository._(this);\n').join()}
     }
     

--- a/lib/src/builder/generators/repository_generator.dart
+++ b/lib/src/builder/generators/repository_generator.dart
@@ -1,3 +1,6 @@
+import 'package:recase/recase.dart';
+import 'package:path/path.dart' as p;
+
 import '../schema.dart';
 import '../elements/table_element.dart';
 import 'insert_generator.dart';
@@ -7,7 +10,7 @@ import 'view_generator.dart';
 class RepositoryGenerator {
   String generateRepositories(AssetState state) {
     return '''
-    extension Repositories on Database {
+    extension ${p.withoutExtension(state.filename).pascalCase}Repositories on Database {
       ${state.tables.values.map((b) => '  ${b.element.name}Repository get ${b.repoName} => ${b.element.name}Repository._(this);\n').join()}
     }
     

--- a/lib/src/builder/schema.dart
+++ b/lib/src/builder/schema.dart
@@ -1,5 +1,5 @@
-
 import 'package:analyzer/dart/element/element.dart';
+import 'package:path/path.dart' as p;
 import 'package:build/build.dart';
 import 'utils.dart';
 
@@ -13,11 +13,12 @@ class SchemaState {
   bool _didFinalize = false;
 
   Map<Element, TableElement> get tables => _assets.values.map((a) => a.tables).reduce((a, b) => {...a, ...b});
-  Map<String, JoinTableElement> get joinTables => _assets.values.map((a) => a.joinTables).reduce((a, b) => {...a, ...b});
+  Map<String, JoinTableElement> get joinTables =>
+      _assets.values.map((a) => a.joinTables).reduce((a, b) => {...a, ...b});
 
   AssetState createForAsset(AssetId assetId) {
     assert(!_didFinalize, 'Schema was already finalized.');
-    var asset = AssetState();
+    var asset = AssetState(p.basename(assetId.path));
     return _assets[assetId] = asset;
   }
 
@@ -34,12 +35,15 @@ class SchemaState {
       _didFinalize = true;
     }
   }
-
 }
 
 class AssetState {
+  final String filename;
+
   Map<Element, TableElement> tables = {};
   Map<String, JoinTableElement> joinTables = {};
+
+  AssetState(this.filename);
 }
 
 class BuilderState {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   dart_style: ^2.2.4
   path: ^1.8.2
   postgres: ^2.5.1
-  recase: ^4.1.0
   source_gen: ^1.2.3
   yaml: ^3.1.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   dart_style: ^2.2.4
   path: ^1.8.2
   postgres: ^2.5.1
+  recase: ^4.1.0
   source_gen: ^1.2.3
   yaml: ^3.1.1
 


### PR DESCRIPTION
Adds a prefix depending on the filename to the generated `Repositories` extension to allow for multiple schema files to be exported,

Previously the name conflict caused an error when trying to *export* multiple extensions with the same name. Imports were not affected.