### PR TITLE
Don't try to generate schema for non-library files

### DIFF
--- a/lib/src/builder/builders/output_builder.dart
+++ b/lib/src/builder/builders/output_builder.dart
@@ -14,6 +14,10 @@ abstract class OutputBuilder implements Builder {
 
   @override
   Future<void> build(BuildStep buildStep) async {
+    if (!await buildStep.resolver.isLibrary(buildStep.inputId)) {
+      return;
+    }
+
     await buildStep.inputLibrary;
 
     try {


### PR DESCRIPTION
When other builders are used in parallel with stormberry, for example json_serializable, generated `part of` files are attempted to be used as complete libraries. This PR skips those files (as the are handled in the actual library file anyways).