### PR TITLE
Don't error when insert/update constructors contain no parameters

### DIFF
--- a/lib/src/builder/generators/insert_generator.dart
+++ b/lib/src/builder/generators/insert_generator.dart
@@ -147,10 +147,12 @@ class InsertGenerator {
       }
     }
 
+    var constructorParameters =
+        requestFields.map((f) => '${f.key.endsWith('?') ? '' : 'required '}this.${f.value}').join(', ');
     return '''
       ${table.annotateWith ?? ''}
       class $requestClassName {
-        $requestClassName({${requestFields.map((f) => '${f.key.endsWith('?') ? '' : 'required '}this.${f.value}').join(', ')},});
+        $requestClassName(${constructorParameters.isNotEmpty ? '{$constructorParameters,}' : ''});
         
         ${requestFields.map((f) => '${f.key} ${f.value};').join('\n')}
       }

--- a/lib/src/builder/generators/insert_generator.dart
+++ b/lib/src/builder/generators/insert_generator.dart
@@ -148,11 +148,12 @@ class InsertGenerator {
     }
 
     var constructorParameters =
-        requestFields.map((f) => '${f.key.endsWith('?') ? '' : 'required '}this.${f.value}').join(', ');
+        requestFields.map((f) => '${f.key.endsWith('?') ? '' : 'required '}this.${f.value},').join(' ');
+
     return '''
       ${table.annotateWith ?? ''}
       class $requestClassName {
-        $requestClassName(${constructorParameters.isNotEmpty ? '{$constructorParameters,}' : ''});
+        $requestClassName(${constructorParameters.isNotEmpty ? '{$constructorParameters}' : ''});
         
         ${requestFields.map((f) => '${f.key} ${f.value};').join('\n')}
       }

--- a/lib/src/builder/generators/update_generator.dart
+++ b/lib/src/builder/generators/update_generator.dart
@@ -72,7 +72,6 @@ class UpdateGenerator {
         return '\${values.add(${c.converter!.toSource()}.tryEncode(r.${c.paramName}))}';
       } else {
         return '\${values.add(r.${c.paramName})}';
-
       }
     }
 
@@ -144,10 +143,13 @@ class UpdateGenerator {
       }
     }
 
+    final constructorParameters =
+        requestFields.map((f) => '${f.key.endsWith('?') ? '' : 'required '}this.${f.value}').join(', ');
+
     return '''
       ${table.annotateWith ?? ''}
       class $requestClassName {
-        $requestClassName({${requestFields.map((f) => '${f.key.endsWith('?') ? '' : 'required '}this.${f.value}').join(', ')},});
+        $requestClassName(${constructorParameters.isNotEmpty ? '{$constructorParameters,}' : ''});
         
         ${requestFields.map((f) => '${f.key} ${f.value};').join('\n')}
       }

--- a/lib/src/builder/generators/update_generator.dart
+++ b/lib/src/builder/generators/update_generator.dart
@@ -144,12 +144,12 @@ class UpdateGenerator {
     }
 
     final constructorParameters =
-        requestFields.map((f) => '${f.key.endsWith('?') ? '' : 'required '}this.${f.value}').join(', ');
+        requestFields.map((f) => '${f.key.endsWith('?') ? '' : 'required '}this.${f.value},').join(' ');
 
     return '''
       ${table.annotateWith ?? ''}
       class $requestClassName {
-        $requestClassName(${constructorParameters.isNotEmpty ? '{$constructorParameters,}' : ''});
+        $requestClassName(${constructorParameters.isNotEmpty ? '{$constructorParameters}' : ''});
         
         ${requestFields.map((f) => '${f.key} ${f.value};').join('\n')}
       }


### PR DESCRIPTION
This can happen when a model is composed entirely of relations which all resolve to `ReferenceColumnElement`s.