### PR TITLE
Updated the `postgres` package to version `3.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
+- You no longer need to use the `Database` class, you can use `Connection.open` or `Pool` directly.
+- `Database` class implements postegres `Session` and `SessionExecutor` classes
+- Extension methods for accessing repositories now extend `Session`
+- Added the ability to create a Pool for your database
 - Updated analyzer dependency to `^6.0.0`
 - Updated dart sdk constraints to `>=2.17.0 <4.0.0`
+
+**BREAKING CHANGES**
+- Updated the `postgres` package to version `3.0.0`. To visit all the breaking changes see their changelog
+- Removed `Database.query` method in favour of `Session.execute` method
+- `Action` and `Query` now accept a Session
+- Repository methods are no longer wrapped in a transaction
+- Removed all fields and methods to execute a transaction in favor of `SessionExecutor.runTx`
 
 # 0.13.1
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,7 +9,7 @@ Future<void> main() async {
   var db = Database(
     port: 2222,
     database: 'dart_test',
-    user: 'postgres',
+    username: 'postgres',
     password: 'postgres',
     useSSL: false,
   );

--- a/example/lib/models/latlng.dart
+++ b/example/lib/models/latlng.dart
@@ -9,11 +9,11 @@ class LatLngConverter extends TypeConverter<LatLng> {
   const LatLngConverter() : super('point');
 
   @override
-  dynamic encode(LatLng value) => PgPoint(value.latitude, value.longitude);
+  dynamic encode(LatLng value) => Point(value.latitude, value.longitude);
 
   @override
   LatLng decode(dynamic value) {
-    if (value is PgPoint) {
+    if (value is Point) {
       return LatLng(value.latitude, value.longitude);
     } else {
       var m = RegExp(r'\((.+),(.+)\)').firstMatch(value.toString());

--- a/lib/src/builder/elements/table_element.dart
+++ b/lib/src/builder/elements/table_element.dart
@@ -95,7 +95,9 @@ class TableElement {
 
   late List<FieldElement> allFields = element.fields
       .cast<FieldElement>()
-      .followedBy(element.allSupertypes.expand((t) => t.isDartCoreObject ? [] : t.element.fields))
+      .followedBy(element.allSupertypes
+          .expand((t) => t.isDartCoreObject ? <FieldElement>[] : t.element.fields))
+      .where((e) => !e.hasInitializer)
       .toList();
 
   void prepareColumns() {

--- a/lib/src/builder/generators/repository_generator.dart
+++ b/lib/src/builder/generators/repository_generator.dart
@@ -1,8 +1,8 @@
 import 'package:path/path.dart' as p;
 
 import '../../core/case_style.dart';
-import '../schema.dart';
 import '../elements/table_element.dart';
+import '../schema.dart';
 import 'insert_generator.dart';
 import 'update_generator.dart';
 import 'view_generator.dart';
@@ -10,7 +10,7 @@ import 'view_generator.dart';
 class RepositoryGenerator {
   String generateRepositories(AssetState state) {
     return '''
-    extension ${CaseStyle.pascalCase.transform(p.withoutExtension(state.filename))}Repositories on Database {
+    extension ${CaseStyle.pascalCase.transform(p.withoutExtension(state.filename))}Repositories on Session {
       ${state.tables.values.map((b) => '  ${b.element.name}Repository get ${b.repoName} => ${b.element.name}Repository._(this);\n').join()}
     }
     
@@ -35,7 +35,7 @@ class RepositoryGenerator {
         ${hasKeyAutoInc ? 'Keyed' : ''}ModelRepositoryInsert<${table.element.name}InsertRequest>, 
         ModelRepositoryUpdate<${table.element.name}UpdateRequest>
         ${keyType != null ? ', ModelRepositoryDelete<$keyType>' : ''} {
-        factory $repoName._(Database db) = _$repoName;
+        factory $repoName._(Session db) = _$repoName;
          
         ${ViewGenerator().generateRepositoryMethods(table, abstract: true)} 
       }

--- a/lib/src/builder/generators/update_generator.dart
+++ b/lib/src/builder/generators/update_generator.dart
@@ -92,13 +92,13 @@ class UpdateGenerator {
         Future<void> update(List<${table.element.name}UpdateRequest> requests) async {
           if (requests.isEmpty) return;
           var values = QueryValues();
-          await db.query(
-            'UPDATE "${table.tableName}"\\n'
+          await db.execute(
+            Sql.named('UPDATE "${table.tableName}"\\n'
             'SET ${setColumns.map((c) => '"${c.columnName}" = COALESCE(UPDATED."${c.columnName}", "${table.tableName}"."${c.columnName}")').join(', ')}\\n'
             'FROM ( VALUES \${requests.map((r) => '( ${updateColumns.map(toUpdateValue).join(', ')} )').join(', ')} )\\n'
             'AS UPDATED(${updateColumns.map((c) => '"${c.columnName}"').join(', ')})\\n'
-            'WHERE $whereClause',
-            values.values,
+            'WHERE $whereClause'),
+            parameters: values.values,
           );
           ${deepUpdates.isNotEmpty ? deepUpdates.join() : ''}
         }

--- a/lib/src/cli/migration/inspector.dart
+++ b/lib/src/cli/migration/inspector.dart
@@ -5,7 +5,7 @@ Future<DatabaseSchema> inspectDatabaseSchema(Database db) async {
   //ignore: prefer_const_constructors
   var schema = DatabaseSchema({});
 
-  var tables = await db.query(
+  var tables = await db.execute(
       "SELECT * FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'");
   for (var row in tables) {
     var tableMap = row.toColumnMap();
@@ -14,8 +14,8 @@ Future<DatabaseSchema> inspectDatabaseSchema(Database db) async {
     var tableScheme = TableSchema(tableName, columns: {}, constraints: [], indexes: []);
     schema.tables[tableName] = tableScheme;
 
-    var columns =
-        await db.query("SELECT * FROM information_schema.columns WHERE table_name = '$tableName'");
+    var columns = await db
+        .execute("SELECT * FROM information_schema.columns WHERE table_name = '$tableName'");
     for (var row in columns) {
       var columnMap = row.toColumnMap();
       var columnName = columnMap['column_name'] as String;
@@ -41,7 +41,7 @@ Future<DatabaseSchema> inspectDatabaseSchema(Database db) async {
     }
   }
 
-  var constraints = await db.query("""
+  var constraints = await db.execute("""
       SELECT tc.constraint_name, tc.constraint_type, 
         (array_agg(kcu.table_name))[1] as src_table,
         array_to_json(array_agg(DISTINCT kcu.column_name)) as src_columns,
@@ -92,7 +92,7 @@ Future<DatabaseSchema> inspectDatabaseSchema(Database db) async {
     }
   }
 
-  var indexes = await db.query(r"""
+  var indexes = await db.execute(r"""
       SELECT * FROM pg_catalog.pg_indexes WHERE schemaname = 'public' AND indexname LIKE '\_\_%'
     """);
   for (var row in indexes) {

--- a/lib/src/core/annotations.dart
+++ b/lib/src/core/annotations.dart
@@ -1,4 +1,5 @@
-import 'database.dart';
+import 'package:postgres/postgres.dart';
+
 import 'table_index.dart';
 import 'transformer.dart';
 
@@ -147,7 +148,8 @@ class BindTo {
 /// {@category Queries & Actions}
 abstract class Action<T> {
   const Action();
-  Future<void> apply(Database db, T request);
+
+  Future<void> apply(Session db, T request);
 }
 
 /// Extend this to define a custom query.
@@ -155,5 +157,6 @@ abstract class Action<T> {
 /// {@category Queries & Actions}
 abstract class Query<T, U> {
   const Query();
-  Future<T> apply(Database db, U params);
+
+  Future<T> apply(Session db, U params);
 }

--- a/lib/src/core/query_params.dart
+++ b/lib/src/core/query_params.dart
@@ -6,7 +6,13 @@ class QueryParams {
   final int? offset;
   final Map<String, dynamic>? values;
 
-  const QueryParams({this.where, this.orderBy, this.limit, this.offset, this.values});
+  const QueryParams({
+    this.where,
+    this.orderBy,
+    this.limit,
+    this.offset,
+    this.values,
+  });
 }
 
 /// {@nodoc}

--- a/lib/src/internals/base_repository.dart
+++ b/lib/src/internals/base_repository.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:postgres/postgres.dart';
 
 import '../core/annotations.dart';
-import '../core/database.dart';
 import '../core/query_params.dart';
 import 'view_query.dart';
 
@@ -15,7 +15,7 @@ abstract class ModelRepository {
 }
 
 abstract class BaseRepository implements ModelRepository {
-  final Database db;
+  final Session db;
 
   final String tableName;
   final String? keyName;
@@ -37,12 +37,8 @@ abstract class BaseRepository implements ModelRepository {
     return query.apply(db, params);
   }
 
-  Future<T> transaction<T>(Runnable<T> runnable) {
-    return db.runTransaction(runnable);
-  }
-
   @override
   Future<void> run<T>(Action<T> action, T request) {
-    return transaction(() => action.apply(db, request));
+    return action.apply(db, request);
   }
 }

--- a/lib/src/internals/delete_repository.dart
+++ b/lib/src/internals/delete_repository.dart
@@ -1,3 +1,5 @@
+import 'package:postgres/postgres.dart';
+
 import '../core/query_params.dart';
 import 'base_repository.dart';
 
@@ -11,15 +13,14 @@ mixin RepositoryDeleteMixin<DeleteRequest> on BaseRepository
   Future<void> delete(List<DeleteRequest> keys) async {
     if (keys.isEmpty) return;
     var values = QueryValues();
-    await db.query(
-      'DELETE FROM "$tableName"\n'
-      'WHERE "$tableName"."$keyName" IN ( ${keys.map((k) => values.add(k)).join(', ')} )',
-      values.values,
-    );
+    await db.execute(Sql.named('''
+      DELETE FROM "$tableName"
+      WHERE "$tableName"."$keyName" IN ( ${keys.map((k) => values.add(k)).join(', ')} )
+    '''), parameters: values.values);
   }
 
   @override
-  Future<void> deleteOne(DeleteRequest key) => transaction(() => delete([key]));
+  Future<void> deleteOne(DeleteRequest key) => delete([key]);
   @override
-  Future<void> deleteMany(List<DeleteRequest> keys) => transaction(() => delete(keys));
+  Future<void> deleteMany(List<DeleteRequest> keys) => delete(keys);
 }

--- a/lib/src/internals/insert_repository.dart
+++ b/lib/src/internals/insert_repository.dart
@@ -15,9 +15,9 @@ mixin RepositoryInsertMixin<InsertRequest> on BaseRepository
   Future<void> insert(List<InsertRequest> requests);
 
   @override
-  Future<void> insertOne(InsertRequest request) => transaction(() => insert([request]));
+  Future<void> insertOne(InsertRequest request) => insert([request]);
   @override
-  Future<void> insertMany(List<InsertRequest> requests) => transaction(() => insert(requests));
+  Future<void> insertMany(List<InsertRequest> requests) => insert(requests);
 }
 
 mixin KeyedRepositoryInsertMixin<InsertRequest> on BaseRepository
@@ -25,8 +25,11 @@ mixin KeyedRepositoryInsertMixin<InsertRequest> on BaseRepository
   Future<List<int>> insert(List<InsertRequest> requests);
 
   @override
-  Future<int> insertOne(InsertRequest request) =>
-      transaction(() => insert([request])).then((r) => r.first);
+  Future<int> insertOne(InsertRequest request) async {
+    final results = await insert([request]);
+    return results.first;
+  }
+
   @override
-  Future<List<int>> insertMany(List<InsertRequest> requests) => transaction(() => insert(requests));
+  Future<List<int>> insertMany(List<InsertRequest> requests) => insert(requests);
 }

--- a/lib/src/internals/text_encoder.dart
+++ b/lib/src/internals/text_encoder.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:postgres/postgres.dart';
+import 'package:postgres/postgres.dart' hide Type;
 
 import '../core/converter.dart';
 
@@ -179,7 +179,7 @@ class _TextEncoder {
       return _encodeString(value, quotes);
     } else if (value is DateTime) {
       return _encodeDateTime(value, quotes, isDateOnly: false);
-    } else if (value is PgPoint) {
+    } else if (value is Point) {
       return _encodePoint(value, quotes);
     } else if (value is Map) {
       return _encodeJSON(value, quotes);
@@ -187,7 +187,7 @@ class _TextEncoder {
       return _encodeList(value, quotes);
     }
 
-    throw PostgreSQLException("Could not infer type of value '$value'.");
+    throw PgException("Could not infer type of value '$value'.");
   }
 
   String _encodeString(String text, QuoteStyle quotes) {
@@ -262,7 +262,7 @@ class _TextEncoder {
     return _encodeString(json.encode(value), quotes);
   }
 
-  String _encodePoint(PgPoint value, QuoteStyle quotes) {
+  String _encodePoint(Point value, QuoteStyle quotes) {
     return _encodeString(
         '(${_encodeNumber(value.latitude)},${_encodeNumber(value.longitude)})', quotes);
   }

--- a/lib/src/internals/update_repository.dart
+++ b/lib/src/internals/update_repository.dart
@@ -8,9 +8,9 @@ abstract class ModelRepositoryUpdate<UpdateRequest> {
 mixin RepositoryUpdateMixin<UpdateRequest> on BaseRepository
     implements ModelRepositoryUpdate<UpdateRequest> {
   @override
-  Future<void> updateOne(UpdateRequest request) => transaction(() => update([request]));
+  Future<void> updateOne(UpdateRequest request) => update([request]);
   @override
-  Future<void> updateMany(List<UpdateRequest> requests) => transaction(() => update(requests));
+  Future<void> updateMany(List<UpdateRequest> requests) => update(requests);
 
   Future<void> update(List<UpdateRequest> requests);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   file: ^7.0.0
   glob: ^2.1.1
   path: ^1.8.2
-  postgres: ^2.5.1
+  postgres: ^3.0.3
   source_gen: ^1.2.3
   yaml: ^3.1.1
 

--- a/test/analyze/analyze_test.dart
+++ b/test/analyze/analyze_test.dart
@@ -43,7 +43,7 @@ void main() {
           double? get randomFloat;
           bool get isEnabled;
           DateTime get howLate;
-          PgPoint get whereTo;
+          Point get whereTo;
         }
       ''');
 
@@ -118,7 +118,7 @@ void main() {
         isFieldColumn(
           columnName: 'where_to',
           sqlType: 'point',
-          dartType: 'PgPoint',
+          dartType: 'Point',
           paramName: 'whereTo',
           isList: false,
           isNullable: false,

--- a/test/config/tester.dart
+++ b/test/config/tester.dart
@@ -13,11 +13,12 @@ StormberryTester useTester({String? schema, bool cleanup = false}) {
 
   setUp(() async {
     tester.db = Database(
-        host: 'localhost',
-        port: 5432,
-        database: 'postgres',
-        user: 'postgres',
-        password: 'postgres');
+      host: 'localhost',
+      port: 5432,
+      database: 'postgres',
+      username: 'postgres',
+      password: 'postgres',
+    );
     if (schema != null) {
       await tester.db.migrateTo(schema);
     }
@@ -25,8 +26,8 @@ StormberryTester useTester({String? schema, bool cleanup = false}) {
 
   tearDown(() async {
     if (cleanup) {
-      await tester.db.query('DROP SCHEMA public CASCADE;');
-      await tester.db.query('CREATE SCHEMA public;');
+      await tester.db.execute('DROP SCHEMA public CASCADE;');
+      await tester.db.execute('CREATE SCHEMA public;');
     }
     await tester.db.close();
   });
@@ -45,8 +46,8 @@ extension SchemaChanger on Database {
       printDiff(diff);
     }
 
-    await runTransaction(() async {
-      await patchSchema(this, diff);
+    await runTx((session) async {
+      await patchSchema(session, diff);
     });
 
     return diff;


### PR DESCRIPTION
- You no longer need to use the `Database` class, you can use `Connection.open` or `Pool` directly.
 - `Database` class implements postegres `Session` and `SessionExecutor` classes
 - Extension methods for accessing repositories now extend `Session`
 - Added the ability to create a Pool for your database

 **BREAKING CHANGES**
 - Updated the `postgres` package to version `3.0.0`. To visit all the breaking changes see their changelog
 - Removed `Database.query` method in favour of `Session.execute` method
 - `Action` and `Query` now accept a Session
 - Repository methods are no longer wrapped in a transaction
 - Removed all fields and methods to execute a transaction in favor of `SessionExecutor.runTx`

Blocked by #70 

Fixs #69 #5 